### PR TITLE
Add an Alias for Kodansha to match ComicVine

### DIFF
--- a/assets/publishers/publishers.txt
+++ b/assets/publishers/publishers.txt
@@ -363,7 +363,7 @@ Key Publications|comics/Key Publications.png
 Kill Time Communication|manga/Kill Time Communication.png
 Kitchen Sink|comics/Kitchen Sink.png
 KiZoic|comics/KiZoic.png
-Kodansha#Kodansha USA#Kodansha Comics|comics/Kodansha.png
+Kodansha#Kodansha USA#Kodansha Comics#Kodansha Comics USA|comics/Kodansha.png
 Kult Editionen|comics/Kult Editionen.png
 Kurokawa|comics/Kurokawa.png
 L. Miller|comics/L. Miller.png


### PR DESCRIPTION
Matches ComicVine's naming "Kodansha Comics USA".