### PR TITLE
Fixed broken links to specific Wiki pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,8 +317,8 @@
                     <li>Full Localization support</li>
                     <li>Built-in Theme downloading and updating</li>
                     <li>Frequent updates with new features</li>
-                    <li>Available on many devices and platforms including <a target="_blank" href="https://wiki.kavitareader.com/en/guides/misc/paperback">Paperback</a>, 
-                        <a target="_blank" href="https://wiki.kavitareader.com/en/guides/misc/tachiyomi">Tachiyomi</a> and <a target="_blank" href="https://wiki.kavitareader.com/en/guides/misc/cdisplayex">CDisplayEx</a></li>
+                    <li>Available on many devices and platforms including <a target="_blank" href="https://wiki.kavitareader.com/guides/3rdparty/paperback/">Paperback</a>, 
+                        <a target="_blank" href="https://wiki.kavitareader.com/guides/3rdparty/tachi-like/">Mihon (Tachiyomi Fork)</a> and <a target="_blank" href="https://wiki.kavitareader.com/guides/3rdparty/cdisplayex/">CDisplayEx</a></li>
                 </ul>
             </div>
         </div>
@@ -330,7 +330,7 @@
 
     <div id=download class="download">
         <div class="container" style="padding-top: 20px">
-            <a class="btn btn-primary" style="background-color: #4ac694; color: white; border-color: #4ac694; width: 100%" href="https://wiki.kavitareader.com/installation/getting-started#installation-methods">
+            <a class="btn btn-primary" style="background-color: #4ac694; color: white; border-color: #4ac694; width: 100%" href="https://wiki.kavitareader.com/getting-started/#installation-methods">
                 Get Started with Kavita
             </a>
         </div>


### PR DESCRIPTION
Noticed that it was pointing to broken links for the Getting started hotlink as well as the third party reader hotlinks. Changed them to the current wiki page as well as updated the Tachiyomi hotlink to mention that it's Mihon, a fork of Tachi